### PR TITLE
Fix calling convention preconditions

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -156,7 +156,7 @@ def mk_eqs_arm_none_eabi_gnu (var_c_args, var_c_rets, c_imem, c_omem,
 		init_save_seq = mk_stack_sequence (r0, 4, st, word32T,
 			len (var_c_rets))
 		(_, last_arg_addr) = arg_seq[len (var_c_args) - 1]
-		preconds += [mk_less_eq (sp, addr)
+		preconds += [mk_less_eq (r0, addr)
 			for (_, addr) in init_save_seq[-1:]]
 		if last_arg_addr:
 			preconds += [mk_less (last_arg_addr, addr)


### PR DESCRIPTION
Before this fix, the preconditions for function calls at the assembly level were too weak. In particular, in the case of a function which returns a large value on the stack, they allowed for a return value region in high memory that wraps around 0, potentially clobbering a stack in low memory. This prevented the tool from being able to verify refinement in a few specific cases, as the SMT solver was able to find counterexamples where this clobbering happens.

This fix strengthens the preconditions to forbid such clobbering, aligning with the calling convention we are modeling.

This fix effectively changes part of the precondition from `sp <= r0 && sp <= r0 + len(var_c_rets)` to `sp <= r0 <= r0 + len(var_c_rets)`. The former permits the problematic case where `r0 + len(var_c_rets) < r0`, whereas the latter does not.